### PR TITLE
Revise libcufile recipe / fix tests.

### DIFF
--- a/recipes/libcufile/build.sh
+++ b/recipes/libcufile/build.sh
@@ -4,7 +4,7 @@
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/lib
 mkdir -p ${PREFIX}/gds
-mv -v etc ${PREFIX}/etc
+rm -rv etc
 mv -v man ${PREFIX}/man
 mv -v samples ${PREFIX}/gds/samples
 mv -v tools ${PREFIX}/gds/tools

--- a/recipes/libcufile/build.sh
+++ b/recipes/libcufile/build.sh
@@ -4,8 +4,8 @@
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/lib
 mkdir -p ${PREFIX}/gds
-mv samples ${PREFIX}/gds/samples
-mv tools ${PREFIX}/gds/tools
+mv -v samples ${PREFIX}/gds/samples
+mv -v tools ${PREFIX}/gds/tools
 [[ -d pkg-config ]] && mv pkg-config ${PREFIX}/lib/pkgconfig
 [[ -d "$PREFIX/lib/pkgconfig" ]] && sed -E -i "s|cudaroot=.+|cudaroot=$PREFIX|g" $PREFIX/lib/pkgconfig/cufile*.pc
 

--- a/recipes/libcufile/build.sh
+++ b/recipes/libcufile/build.sh
@@ -4,6 +4,8 @@
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/lib
 mkdir -p ${PREFIX}/gds
+mv -v etc ${PREFIX}/etc
+mv -v man ${PREFIX}/man
 mv -v samples ${PREFIX}/gds/samples
 mv -v tools ${PREFIX}/gds/tools
 [[ -d pkg-config ]] && mv pkg-config ${PREFIX}/lib/pkgconfig

--- a/recipes/libcufile/conda_build_config.yaml
+++ b/recipes/libcufile/conda_build_config.yaml
@@ -1,2 +1,2 @@
-arm_variant_type: # [aarch64]
-  - sbsa          # [aarch64]
+arm_variant_type:  # [aarch64]
+  - sbsa           # [aarch64]

--- a/recipes/libcufile/meta.yaml
+++ b/recipes/libcufile/meta.yaml
@@ -24,28 +24,33 @@ build:
 
 test:
   commands:
+    # Note that the version of libcufile does not match
+    # {{ version.split(".")[0] }} but the major version of libcufile_rdma does
+    # match that. Also we must drop the last component of the version when
+    # finding the versioned .so file.
+    {% set full_version = version.split(".")[:-1] | join(".") %}
     - test -f $PREFIX/etc/cufile.json
-    - test -L $PREFIX/lib/libcufile.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/lib/libcufile.so.0
     - test -L $PREFIX/lib/libcufile_rdma.so.{{ version.split(".")[0] }}  # [linux64]
-    - test -L $PREFIX/lib/libcufile.so.{{ version }}
-    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version }}  # [linux64]
-    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/lib/libcufile.so.{{ full_version }}
+    - test -L $PREFIX/lib/libcufile_rdma.so.{{ full_version }}  # [linux64]
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile.so.0
     - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version.split(".")[0] }}  # [linux64]
-    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version }}
-    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version }}  # [linux64]
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ full_version }}
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ full_version }}  # [linux64]
 
 outputs:
   - name: libcufile
     build:
       missing_dso_whitelist:
         - "*/libcuda.so.*"
-        # TODO: The following libraries are required for libcufile_rdma, which
-        # is only linux64 (not aarch64). What provides these?
-        # rdma-core-devel-cos7-x86_64 is close, but lacks the ".so.1" suffix.
-        # Only the ".so" files are provided by that package.
-        - "*/libmlx5.so.1"
-        - "*/librdmacm.so.1"
-        - "*/libibverbs.so.1"
+        # TODO: The following libraries are required for libcufile_rdma.so,
+        # which is only for linux64 (not aarch64). What provides these?
+        # rdma-core-devel-cos7-x86_64 is close, but doesn't seem to work.
+        # Perhaps because the files are in a sysroot location?
+        - "*/libmlx5.so.*"
+        - "*/librdmacm.so.*"
+        - "*/libibverbs.so.*"
     files:
       - etc/cufile.json
       - lib/libcufile*.so.*
@@ -60,7 +65,6 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-        - rdma-core-devel-cos7-x86_64  # [linux64]
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     # Tests are defined at the top level, due to package/output name conflicts.

--- a/recipes/libcufile/meta.yaml
+++ b/recipes/libcufile/meta.yaml
@@ -26,19 +26,26 @@ test:
   commands:
     - test -f $PREFIX/etc/cufile.json
     - test -L $PREFIX/lib/libcufile.so.{{ version.split(".")[0] }}
-    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version.split(".")[0] }}  # [linux64]
     - test -L $PREFIX/lib/libcufile.so.{{ version }}
-    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version }}
+    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version }}  # [linux64]
     - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version.split(".")[0] }}
-    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version.split(".")[0] }}  # [linux64]
     - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version }}
-    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version }}
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version }}  # [linux64]
 
 outputs:
   - name: libcufile
     build:
       missing_dso_whitelist:
-        - "*/libcuda.so.*"  # [linux]
+        - "*/libcuda.so.*"
+        # TODO: The following libraries are required for libcufile_rdma, which
+        # is only linux64 (not aarch64). What provides these?
+        # rdma-core-devel-cos7-x86_64 is close, but lacks the ".so.1" suffix.
+        # Only the ".so" files are provided by that package.
+        - "*/libmlx5.so.1"
+        - "*/librdmacm.so.1"
+        - "*/libibverbs.so.1"
     files:
       - etc/cufile.json
       - lib/libcufile*.so.*
@@ -53,6 +60,7 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - rdma-core-devel-cos7-x86_64  # [linux64]
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     # Tests are defined at the top level, due to package/output name conflicts.

--- a/recipes/libcufile/meta.yaml
+++ b/recipes/libcufile/meta.yaml
@@ -29,7 +29,6 @@ test:
     # match that. Also we must drop the last component of the version when
     # finding the versioned .so file.
     {% set full_version = version.split(".")[:-1] | join(".") %}
-    - test -f $PREFIX/etc/cufile.json
     - test -L $PREFIX/lib/libcufile.so.0
     - test -L $PREFIX/lib/libcufile_rdma.so.{{ version.split(".")[0] }}  # [linux64]
     - test -L $PREFIX/lib/libcufile.so.{{ full_version }}
@@ -45,7 +44,6 @@ outputs:
       missing_dso_whitelist:
         - "*/libcuda.so.*"
     files:
-      - etc/cufile.json
       - lib/libcufile*.so.*
       - targets/{{ target_name }}/lib/libcufile*.so.*
     requirements:

--- a/recipes/libcufile/meta.yaml
+++ b/recipes/libcufile/meta.yaml
@@ -20,18 +20,29 @@ source:
 
 build:
   number: 0
-  skip: true  # [not linux]
+  skip: true  # [not (linux64 or aarch64)]
+
+test:
+  commands:
+    - test -f $PREFIX/etc/cufile.json
+    - test -L $PREFIX/lib/libcufile.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/lib/libcufile.so.{{ version }}
+    - test -L $PREFIX/lib/libcufile_rdma.so.{{ version }}
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version.split(".")[0] }}
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version.split(".")[0] }}
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile.so.{{ version }}
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so.{{ version }}
 
 outputs:
   - name: libcufile
     build:
       missing_dso_whitelist:
-        - "*/libcuda.so.*"                     # [linux]
-      run_exports:
-        - {{ pin_subpackage("libcufile", max_pin="x") }}
+        - "*/libcuda.so.*"  # [linux]
     files:
-      - lib/libcufile*.so.*
       - etc/cufile.json
+      - lib/libcufile*.so.*
+      - targets/{{ target_name }}/lib/libcufile*.so.*
     requirements:
       build:
         - {{ compiler("c") }}
@@ -44,18 +55,15 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
-    test:
-      commands:
-        - test -f $PREFIX/lib/libcufile.so.*
-        - test -f $PREFIX/lib/libcufile_rdma.so.*
-        - test -f $PREFIX/etc/cufile.json
+    # Tests are defined at the top level, due to package/output name conflicts.
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
-      summary: |
-        Library for GPU Direct Storage with CUDA
+      summary: Library for NVIDIA GPUDirect Storage
+      description: |
+        The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: libcufile-dev
@@ -63,42 +71,58 @@ outputs:
       run_exports:
         - {{ pin_subpackage("libcufile", max_pin="x") }}
     files:
-      - include/cufile*
       - lib/libcufile*.so
+      - lib/pkgconfig
+      - targets/{{ target_name }}/include
       - targets/{{ target_name }}/lib/libcufile*.so
-      - targets/{{ target_name }}/include/cufile*
       - man/man3
     requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("libcufile", exact=True) }}
       run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - libcufile-static >={{ version }}
     test:
       commands:
         - test -L $PREFIX/lib/libcufile.so
+        - test -L $PREFIX/lib/libcufile_rdma.so
         - test -f $PREFIX/targets/{{ target_name }}/include/cufile.h
         - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile.so
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libcufile_rdma.so
         - test -d $PREFIX/man/man3
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
-      summary: |
-        Library for GPU Direct Storage with CUDA
+      summary: Library for NVIDIA GPUDirect Storage
+      description: |
+        The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: libcufile-static
     files:
-      - targets/{{ target_name }}/lib/libcufile*_static.a  
+      - targets/{{ target_name }}/lib/libcufile*_static.a
     requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - sysroot_{{ target_platform }} 2.17    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -f $PREFIX/targets/{{ target_name }}/lib/libcufile_static.a
@@ -108,14 +132,15 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
-      summary: |
-        Library for GPU Direct Storage with CUDA
+      summary: Library for NVIDIA GPUDirect Storage
+      description: |
+        The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: gds-tools
     files:
       - gds/samples
-      - gds/tools  
+      - gds/tools
     requirements:
       build:
         - {{ compiler("c") }}
@@ -125,7 +150,7 @@ outputs:
       host:
         - cuda-version {{ cuda_version }}
         - libcufile-dev {{ version }}
-        - libnuma                              # [linux]
+        - libnuma  # [linux]
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - {{ pin_subpackage("libcufile", max_pin="x") }}
@@ -140,8 +165,9 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
-      summary: |
-        Library for GPU Direct Storage with CUDA
+      summary: Library for NVIDIA GPUDirect Storage
+      description: |
+        The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
 about:
@@ -149,8 +175,9 @@ about:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: LICENSE
   license_url: https://docs.nvidia.com/cuda/eula/index.html
-  summary: |
-    Library for GPU Direct Storage with CUDA
+  summary: Library for NVIDIA GPUDirect Storage
+  description: |
+    The cuFile library provides a direct data path between GPU memory and storage.
   doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
 extra:

--- a/recipes/libcufile/meta.yaml
+++ b/recipes/libcufile/meta.yaml
@@ -44,13 +44,6 @@ outputs:
     build:
       missing_dso_whitelist:
         - "*/libcuda.so.*"
-        # TODO: The following libraries are required for libcufile_rdma.so,
-        # which is only for linux64 (not aarch64). What provides these?
-        # rdma-core-devel-cos7-x86_64 is close, but doesn't seem to work.
-        # Perhaps because the files are in a sysroot location?
-        - "*/libmlx5.so.*"
-        - "*/librdmacm.so.*"
-        - "*/libibverbs.so.*"
     files:
       - etc/cufile.json
       - lib/libcufile*.so.*
@@ -61,6 +54,7 @@ outputs:
         - {{ compiler("cxx") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} 2.17   # [linux]
+        - {{ cdt("rdma-core-devel") }}  # [linux64]
       host:
         - cuda-version {{ cuda_version }}
       run:


### PR DESCRIPTION
This PR addresses several issues in the libcufile recipe. Changes include:
- `etc/cufile.json` and `man` were not being packaged correctly - these shouldn't go in the `targets` directory as I understand
- Need to skip ppc64le when migrator is enabled (fixed skip logic)
- Added more specific tests for package contents and moved tests to the top level (due to package name conflicts that otherwise prevent tests from running)
- Updated summary/description a bit (description was missing)

Tests are passing locally, so I'll open this PR. However, we have one TODO item that needs addressed: if we intend to package `libcufile_rdma.so` (which is only available on linux64 and not aarch64), we need to figure out how to supply the missing DSOs. See PR for details.